### PR TITLE
Updates to schemas with minor corrections and introduction of rate_plan_hierarchy.xsd schema

### DIFF
--- a/common_definitions.xsd
+++ b/common_definitions.xsd
@@ -45,14 +45,22 @@ Complex Types
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element form="qualified" name="serviceSubClasses" minOccurs="0">
+            <xs:element form="qualified" name="rateCodes" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>List of applicable service subclasses, eg. "Service Class 1 rate II"</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" name="serviceSubClass"
+                        <xs:element maxOccurs="unbounded" name="rateCode"
                             type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element form="qualified" minOccurs="0" name="ratePlans">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded"
+                            name="ratePlanCodeUnique" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -93,6 +101,7 @@ Complex Types
             <xs:element form="qualified" name="startDate" type="xs:date"/>
             <xs:element name="endDate" form="qualified" type="xs:date"
                 minOccurs="0"/>
+            <xs:element minOccurs="0" name="expectedEndDate" type="xs:date"/>
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="dateTimeIntervalType">

--- a/minimum_charges.xsd
+++ b/minimum_charges.xsd
@@ -5,7 +5,15 @@
     <xs:element name="minimumCharges">
         <xs:complexType>
             <xs:sequence>
-                <xs:element maxOccurs="unbounded" name="minimumCharge" type="chargeType"/>
+                <xs:element maxOccurs="unbounded" name="minimumCharge">
+                    <xs:complexType>
+                        <xs:complexContent>
+                            <xs:extension base="chargeType">
+                                <xs:attribute ref="ratePlanCodeUnique"/>
+                            </xs:extension>
+                        </xs:complexContent>
+                    </xs:complexType>
+                </xs:element>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/rate_plan_data_output.xsd
+++ b/rate_plan_data_output.xsd
@@ -15,7 +15,7 @@
     <xs:element name="ratePlanScenario">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="ratePlanSelection"/>
+                <xs:element ref="ratePlanSelection" maxOccurs="unbounded"/>
                 <xs:element name="modifierSelection" maxOccurs="unbounded" minOccurs="0">
                     <xs:complexType>
                         <xs:complexContent>
@@ -81,7 +81,7 @@
                         </xs:complexContent>
                     </xs:complexType>
                 </xs:element>
-                <xs:element name="ScenarioSettings">
+                <xs:element name="scenarioSettings">
                     <xs:annotation>
                         <xs:documentation>Each ratePlanScenario may have one or multiple "branches" of charge options which depend on attributes specific to each scenario instance. Examples are: parameters determined by the utility (e.g. contracted electric demand) or by the scenanrio location falling within a rate plan territory.</xs:documentation>
                     </xs:annotation>
@@ -93,9 +93,8 @@
                                 </xs:simpleType>
                             </xs:element>
                             <xs:element maxOccurs="1" minOccurs="0" name="icapTag"/>
-                            <xs:element minOccurs="0" name="county" type="xs:string"/>
-                            <xs:element minOccurs="0" name="zipcode" type="xs:string"/>
                             <xs:element minOccurs="0" name="territory" type="xs:string"/>
+                            <xs:element minOccurs="0" name="zipcode" type="xs:string"/>
                             <xs:element minOccurs="0" name="equipment" type="xs:string"/>
                             <xs:element minOccurs="0" ref="phase"/>
                         </xs:sequence>

--- a/rate_plan_hierarchy.xsd
+++ b/rate_plan_hierarchy.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified"
+    vc:minVersion="1.0" vc:maxVersion="1.1">
+    <xs:include schemaLocation="common_definitions.xsd"/>
+    <xs:element name="utilities">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="parentUtility">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="parentIedrOrgAbbreviation">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:maxLength value="3"/>
+                                        <xs:minLength value="3"/>
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                            <xs:element maxOccurs="unbounded" name="iedrOrg">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element form="qualified" name="iedrOrgAbbreviation">
+                                            <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                  <xs:maxLength value="3"/>
+                                                  <xs:minLength value="3"/>
+                                                </xs:restriction>
+                                            </xs:simpleType>
+                                        </xs:element>
+                                        <xs:element name="userFacingUtilityName" type="xs:string"/>
+                                        <xs:element name="utilityOperatingCompany">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                  <xs:element name="iedrOrgAbbreviation"
+                                                  type="xs:string"/>
+                                                  <xs:element name="dpsCompanyId" type="xs:string">
+                                                  <xs:annotation>
+                                                  <xs:documentation>populated by IEDR platform</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element name="serviceType" type="serviceKind"/>
+                                                  <xs:element name="tariff">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="dpsPscNumber" type="xs:string"> </xs:element>
+                                                  <xs:element name="serviceClasses">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element maxOccurs="unbounded"
+                                                  name="serviceClass">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="serviceClassNumber"
+                                                  type="xs:int"/>
+                                                  <xs:element name="serviceClassName"
+                                                  type="xs:string"/>
+                                                  <xs:element name="rateOptions">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element maxOccurs="unbounded"
+                                                  name="rateOption">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="rateCode" type="xs:string"/>
+                                                  <xs:element maxOccurs="unbounded"
+                                                  name="iedrRatePlan">
+                                                  <xs:complexType>
+                                                  <xs:attribute name="ratePlanCodeUnique"/>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/rate_plan_territories.xsd
+++ b/rate_plan_territories.xsd
@@ -2,6 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified"
     vc:minVersion="1.0" vc:maxVersion="1.1">
+    <xs:include schemaLocation="common_definitions.xsd"/>
     <xs:element name="ratePlanTerritories">
         <xs:complexType>
             <xs:sequence>
@@ -23,8 +24,9 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="geographicUnit"/>
+            <xs:element name="geographicUnit" type="xs:string"/>
             <xs:element name="rawValue" type="xs:string"/>
+            <xs:element name="effectivePeriod" type="dateIntervalType"/>
         </xs:sequence>
     </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
made rate plan selection unbounded, removed county as redundant with rate_plan_territory

rate_plan_territories.xsd added effectivePeriod
common_definitions.xsd
added expectedEndDate to dateIntervalType

 rate_plan_hierarchy.xsd introduce draft