### PR TITLE
Post v0.99.3 dev r7

### DIFF
--- a/all_rate_plan_schemas.xsd
+++ b/all_rate_plan_schemas.xsd
@@ -8,6 +8,7 @@
     <xs:include schemaLocation="eligibility.xsd"/>
     <xs:include schemaLocation="holidays.xsd"/>
     <xs:include schemaLocation="rate_plans.xsd"/>
+    <xs:include schemaLocation="rate_plan_hierarchy.xsd"/>
     <xs:include schemaLocation="rate_plan_modifiers.xsd"/>
     <xs:include schemaLocation="rate_plan_territories.xsd"/>
     <xs:include schemaLocation="seasons.xsd"/>

--- a/charges.xsd
+++ b/charges.xsd
@@ -43,12 +43,37 @@
                 </xs:element>
                 <xs:element maxOccurs="unbounded" minOccurs="0" name="exportCredit"
                     type="ChargeType"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="statementCharge"
+                    type="ChargeType"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="ChargeType">
         <xs:sequence>
             <xs:element name="servicePeriod" type="DateIntervalType"/>
+            <xs:element minOccurs="0" name="chargeSourceURL" type="xs:anyURI"/>
+            <xs:element name="sourceDocKind" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The type of official tariff documentation</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="TariffBook"/>
+                        <xs:enumeration value="Statement"/>
+                        <xs:enumeration value="MarketSupplyChargesData"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="tariffBookLeafRange" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="startLeafNbr" type="xs:string"/>
+                        <xs:element name="endLeafNbr" type="xs:string"/>
+                        <xs:element name="dpsCaseNumber" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" name="statementTypeCode" type="xs:string"/>
             <xs:element name="serviceTierNr" type="xs:int" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>Tooltip:<br/> 

--- a/common_definitions.xsd
+++ b/common_definitions.xsd
@@ -96,6 +96,14 @@ If a suffix is added (ex.: "SC1TOU1" ) this field shall be populated with just t
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="customerClasses" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" name="customerClass"
+                            type="CustomerClassKind"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:sequence>
     </xs:complexType>
     <!--
@@ -233,11 +241,36 @@ If a suffix is added (ex.: "SC1TOU1" ) this field shall be populated with just t
 
     <!--
 =======================================
-Enumerations
+Enumerations simpleType
 =======================================
 -->
 
-
+    <xs:simpleType name="CustomerClassKind">
+        <xs:annotation>
+            <xs:documentation>Tooltip:<br/> 
+                    the type of customer that the rate plan applies to such as residential, commercial, industrial, lighting<p/>
+                    
+                    Comment:<br/> 
+                    The type of customer that the tariff applies to such as residential, commercial, industrial, lighting</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255"/>
+            <xs:enumeration value="Commercial"/>
+            <xs:enumeration value=" Commercial Large"/>
+            <xs:enumeration value="Distributed Generation"/>
+            <xs:enumeration value="Industrial"/>
+            <xs:enumeration value="Interruptible"/>
+            <xs:enumeration value="Lighting"/>
+            <xs:enumeration value="Natural Gas Vehicle"/>
+            <xs:enumeration value="Non-residential"/>
+            <xs:enumeration value="Religious"/>
+            <xs:enumeration value="Residential"/>
+            <xs:enumeration value="Street Lighting"/>
+            <xs:enumeration value="Time of Use"/>
+            <xs:enumeration value="Transmission"/>
+            <xs:enumeration value="Transmission Or Substation"/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:simpleType name="MeasurementKind">
         <xs:annotation>
             <xs:documentation>Tooltip:<br/> 
@@ -390,7 +423,6 @@ Enumerations
             </xs:restriction>
         </xs:simpleType>
     </xs:element>
-
     <xs:element name="phases">
         <xs:complexType>
             <xs:sequence>

--- a/rate_plan_data_input.xsd
+++ b/rate_plan_data_input.xsd
@@ -3,18 +3,15 @@
     <xs:include schemaLocation="common_definitions.xsd"/>
     <xs:include schemaLocation="tariff_books.xsd"/>
     <xs:include schemaLocation="tariff_statements.xsd"/>
-    <xs:include schemaLocation="rate_plans.xsd"/>
     <xs:include schemaLocation="rate_plan_modifiers.xsd"/>
-    <xs:include schemaLocation="eligibility.xsd"/>
-    <xs:include schemaLocation="holidays.xsd"/>
-    <xs:include schemaLocation="seasons.xsd"/>
-    <xs:include schemaLocation="service_tier_thresholds.xsd"/>
-    <xs:include schemaLocation="time_of_use_periods.xsd"/>
+    <xs:include schemaLocation="charges_supply.xsd"/>
     <xs:element name="dataTransfer">
         <xs:complexType>
             <xs:sequence>
-                <xs:element maxOccurs="unbounded" ref="tariffBook"/>
+                <xs:element ref="tariffBooks"/>
+                <xs:element ref="ratePlanModifiers"/>
                 <xs:element ref="tariffStatements"/>
+                <xs:element ref="supplyCharges"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/rate_plan_data_output.xsd
+++ b/rate_plan_data_output.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
     <xs:include schemaLocation="common_definitions.xsd"/>
     <xs:include schemaLocation="charges.xsd"/>
-    <xs:include schemaLocation="charges_supply.xsd"/> 
+    <xs:include schemaLocation="charges_supply.xsd"/>
     <xs:include schemaLocation="eligibility.xsd"/>
     <xs:include schemaLocation="holidays.xsd"/>
     <xs:include schemaLocation="rate_plans.xsd"/>
@@ -12,16 +12,106 @@
     <xs:include schemaLocation="time_of_use_periods.xsd"/>
     <xs:include schemaLocation="tariff_statements.xsd"/>
     <xs:include schemaLocation="tariff_books.xsd"/>
-    <xs:element name="ratePlanScenarios">
+    <xs:element name="ratePlanScenarioOptions">
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="ratePlanScenario">
+                <xs:element name="utilities">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="ratePlanOption" maxOccurs="unbounded">
-                                    <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="ratePlan">
+                            <xs:element name="utility">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="parentOrgIedrAbbreviation" minOccurs="0">
+                                            <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                  <xs:maxLength value="3"/>
+                                                  <xs:minLength value="3"/>
+                                                </xs:restriction>
+                                            </xs:simpleType>
+                                        </xs:element>
+                                        <xs:element minOccurs="0" name="parentOrgName"/>
+                                        <xs:element name="iedrOrgs">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                  <xs:element maxOccurs="unbounded" name="iedrOrg">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element form="qualified"
+                                                  name="iedrOrgAbbreviation">
+                                                  <xs:simpleType>
+                                                  <xs:restriction base="xs:string">
+                                                  <xs:maxLength value="3"/>
+                                                  <xs:minLength value="3"/>
+                                                  </xs:restriction>
+                                                  </xs:simpleType>
+                                                  </xs:element>
+                                                  <xs:element name="iedrUserFacingUtilityName"
+                                                  type="xs:string"/>
+                                                  <xs:element name="dpsCompanies">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element maxOccurs="unbounded"
+                                                  name="dpsCompany">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="dpsCompanyId" type="xs:string">
+                                                  <xs:annotation>
+                                                  <xs:documentation>populated by IEDR platform</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element name="operatingCompanies">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="operatingCompany"
+                                                  maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="orgAbbreviation"
+                                                  type="xs:string"/>
+                                                  <xs:element name="serviceType" type="ServiceKind"/>
+                                                  <xs:element name="tariffs">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="tariff" maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="dpsPscNumber" type="xs:string"> </xs:element>
+                                                  <xs:element name="serviceClasses">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element maxOccurs="unbounded"
+                                                  name="serviceClass">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="serviceClassNumber"
+                                                  type="xs:int"/>
+                                                  <xs:element name="serviceClassName"
+                                                  type="xs:string"/>
+                                                  <xs:element name="rates">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element maxOccurs="unbounded" name="rate">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="rateCode" type="xs:string"/>
+                                                  <xs:element name="rateName"/>
+                                                  <xs:element name="ratePlanOptions">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element maxOccurs="unbounded"
+                                                  name="ratePlanOption">
+                                                  <xs:complexType>
+                                                  <xs:attribute name="ratePlanCodeUnique"/>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element name="ratePlanOptions">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="ratePlanOption"
+                                                  maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="ratePlan">
                                                   <xs:complexType>
                                                   <xs:complexContent>
                                                   <xs:extension base="RatePlanType">
@@ -29,56 +119,111 @@
                                                   </xs:extension>
                                                   </xs:complexContent>
                                                   </xs:complexType>
-                                                </xs:element>
-                                                <xs:element minOccurs="0" ref="eligibility"/>
-                                                <xs:element minOccurs="0" ref="seasons"/>
-                                                <xs:element minOccurs="0" ref="holidays"/>
-                                                <xs:element ref="timeOfUsePeriods" minOccurs="0"
+                                                  </xs:element>
+                                                  <xs:element minOccurs="0" ref="eligibility"/>
+                                                  <xs:element minOccurs="0" ref="seasons"/>
+                                                  <xs:element minOccurs="0" ref="holidays"/>
+                                                  <xs:element ref="timeOfUsePeriods" minOccurs="0"
                                                   maxOccurs="1"/>
-                                                <xs:element minOccurs="0"
+                                                  <xs:element minOccurs="0"
                                                   ref="serviceTierThresholds"/>
-                                                <xs:element ref="charges"> </xs:element>
-                                            </xs:sequence>
-                                    </xs:complexType>
-                            </xs:element>
-                            <xs:element name="modifierOption" maxOccurs="unbounded" minOccurs="0"
-                                type="ratePlanModifierType"> </xs:element>
-                            <xs:element name="scenarioInputSettingOptions">
-                                <xs:annotation>
-                                    <xs:documentation>Each ratePlanScenario may have one or multiple "branches" of charge options which depend on attributes specific to each scenario instance. Examples are: parameters determined by the utility (e.g. contracted electric demand) or by the scenanrio location falling within a rate plan territory.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element name="customerClass" maxOccurs="unbounded">
-                                            <xs:simpleType>
-                                                <xs:restriction base="xs:string"/>
-                                            </xs:simpleType>
-                                        </xs:element>
-                                        <xs:element maxOccurs="unbounded" minOccurs="0"
-                                            name="icapTag">
-                                            <xs:complexType>
-                                                <xs:sequence>
-                                                  <xs:element name="icapTagValidPeriod"
-                                                  type="DateIntervalType"/>
-                                                  <xs:element name="icapTagValue" type="xs:int"/>
-                                                  <xs:element name="icapTagValueDefinition"
-                                                  type="MeasureType"/>
+                                                  <xs:element ref="charges"> </xs:element>
+                                                  <xs:element minOccurs="0"
+                                                  ref="scenarioInputSettings"/>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element minOccurs="0" name="modifierOptions">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element name="modifierOption"
+                                                  maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                  <xs:complexContent>
+                                                  <xs:extension base="ratePlanModifierType">
+                                                  <xs:sequence minOccurs="0">
+                                                  <xs:element ref="scenarioInputSettings"/>
+                                                  </xs:sequence>
+                                                  </xs:extension>
+                                                  </xs:complexContent>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element minOccurs="0"
+                                                  ref="scenarioInputSettings"/>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
                                                 </xs:sequence>
                                             </xs:complexType>
                                         </xs:element>
-                                        <xs:element minOccurs="0" name="territoryId"
-                                            type="xs:string" maxOccurs="unbounded"/>
-                                        <xs:element minOccurs="0" name="equipment" type="xs:string"
-                                            maxOccurs="unbounded"/>
-                                        <xs:element minOccurs="0" ref="phase" maxOccurs="unbounded"
-                                        />
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>
-
                     </xs:complexType>
                 </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="scenarioInputSettings">
+        <xs:annotation>
+            <xs:documentation>Each ratePlanScenario may have one or multiple "branches" of charge options which depend on attributes specific to each scenario instance. Examples are: parameters determined by the utility (e.g. contracted electric demand) or by the scenanrio location falling within a rate plan territory.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="scopeOfApplicability"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="icapTag">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="icapTagValidPeriod" type="DateIntervalType"/>
+                            <xs:element name="icapTagValue" type="xs:int"/>
+                            <xs:element name="icapTagValueDefinition" type="MeasureType"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element minOccurs="0" name="territoryId" type="xs:string" maxOccurs="unbounded"/>
+                <xs:element minOccurs="0" name="equipment" type="xs:string" maxOccurs="unbounded"/>
+                <xs:element minOccurs="0" ref="phase" maxOccurs="unbounded"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/rate_plan_data_output.xsd
+++ b/rate_plan_data_output.xsd
@@ -2,6 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
     <xs:include schemaLocation="common_definitions.xsd"/>
     <xs:include schemaLocation="charges.xsd"/>
+    <xs:include schemaLocation="charges_supply.xsd"/> 
     <xs:include schemaLocation="eligibility.xsd"/>
     <xs:include schemaLocation="holidays.xsd"/>
     <xs:include schemaLocation="rate_plans.xsd"/>
@@ -9,6 +10,8 @@
     <xs:include schemaLocation="seasons.xsd"/>
     <xs:include schemaLocation="service_tier_thresholds.xsd"/>
     <xs:include schemaLocation="time_of_use_periods.xsd"/>
+    <xs:include schemaLocation="tariff_statements.xsd"/>
+    <xs:include schemaLocation="tariff_books.xsd"/>
     <xs:element name="ratePlanScenarios">
         <xs:complexType>
             <xs:sequence>

--- a/rate_plans.xsd
+++ b/rate_plans.xsd
@@ -49,6 +49,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
+            <xs:element name="iedrUtilityUserFacingName"/>
             <xs:element name="tariffUtilityName">
                 <xs:simpleType>
                     <xs:annotation>
@@ -63,33 +64,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="tariffUtilityPscNumber">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            an ID assigned by the New York State Department of Public Service, non-unique across service types and utilities<p/>
-                            
-                            Comment:<br/> 
-                            Unique ID from DPS, one utility may have multiple and these are non-unique. There is 1 id per utility service type and some utilities manage multiple utilities</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="3"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="dateDraftUpdate" nillable="true" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            if the rate plan is in draft ("Pending") status, the date that the rate plan draft was last updated<p/>
-                            
-                            Comment:<br/> 
-                            - Date that the rate plan was drafted
-                            - Date formatted in either basic or extended ISO compliant format as “YYYYMMDD” or “YYYY-MM-DD," respectively. </xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:date"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
+            <xs:element minOccurs="0" name="initialDateEffective"/>
             <xs:element name="dateEffective" nillable="false">
                 <xs:simpleType>
                     <xs:annotation>
@@ -116,49 +91,17 @@
                     <xs:restriction base="xs:date"> </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="serviceClassNumber">
+            <xs:element name="dateDraftUpdate" nillable="true" minOccurs="0">
                 <xs:simpleType>
                     <xs:annotation>
                         <xs:documentation>Tooltip:<br/> 
-                            the number of the service class with which this rate plan is associated<p/>
+                            if the rate plan is in draft ("Pending") status, the date that the rate plan draft was last updated<p/>
                             
                             Comment:<br/> 
-                            Number used to group rates by service class</xs:documentation>
+                            - Date that the rate plan was drafted
+                            - Date formatted in either basic or extended ISO compliant format as “YYYYMMDD” or “YYYY-MM-DD," respectively. </xs:documentation>
                     </xs:annotation>
-                    <xs:restriction base="xs:int">
-                        <xs:totalDigits value="3"/>
-                        <xs:minInclusive value="1"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="serviceClassName">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            the name of the service class with which this rate plan is associated<p/>
-                            
-                            Comment:<br/> 
-                            Name of service class</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="40"/>
-                        <xs:whiteSpace value="collapse"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="rateCode" nillable="true">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            an identifier used by utilities to refer to this rate plan or a group of rate plans to which this rate plan belongs<p/>
-                            
-                            Comment:<br/> 
-                            identifier used publicly to refer to the parent rate plan of which this rate is a rate plan permutation</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="10"/>
-                        <xs:whiteSpace value="collapse"/>
-                    </xs:restriction>
+                    <xs:restriction base="xs:date"> </xs:restriction>
                 </xs:simpleType>
             </xs:element>
             <xs:element name="ratePlanTariffId" nillable="true" minOccurs="0">
@@ -191,34 +134,7 @@
                 </xs:simpleType>
             </xs:element>
             <xs:element name="service" nillable="false" type="ServiceKind"> </xs:element>
-            <xs:element name="customerClass" nillable="false" maxOccurs="unbounded">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            the type of customer that the rate plan applies to such as residential, commercial, industrial, lighting<p/>
-                            
-                            Comment:<br/> 
-                            The type of customer that the tariff applies to such as residential, commercial, industrial, lighting</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="255"/>
-                        <xs:enumeration value="Commercial"/>
-                        <xs:enumeration value=" Commercial Large"/>
-                        <xs:enumeration value="Distributed Generation"/>
-                        <xs:enumeration value="Industrial"/>
-                        <xs:enumeration value="Interruptible"/>
-                        <xs:enumeration value="Lighting"/>
-                        <xs:enumeration value="Natural Gas Vehicle"/>
-                        <xs:enumeration value="Non-residential"/>
-                        <xs:enumeration value="Religious"/>
-                        <xs:enumeration value="Residential"/>
-                        <xs:enumeration value="Street Lighting"/>
-                        <xs:enumeration value="Time of Use"/>
-                        <xs:enumeration value="Transmission"/>
-                        <xs:enumeration value="Transmission Or Substation"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
+            <xs:element maxOccurs="unbounded" name="customerClass" type="CustomerClassKind"> </xs:element>
             <xs:element minOccurs="0" name="territories">
                 <xs:complexType>
                     <xs:sequence>


### PR DESCRIPTION
updated rate plan to remove redundant service class and rate code fields
updated output to allow for multiple scenarios with global setting options at each node
includes scopeOfApplicability in ChargeType as optional, included export and supply charge options