### PR TITLE
Post v0.99.4 dev r2 kds

### DIFF
--- a/charges.xsd
+++ b/charges.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified"
-    vc:minVersion="1.0" vc:maxVersion="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified" vc:minVersion="1.0" vc:maxVersion="1.1">
     <xs:include schemaLocation="common_definitions.xsd"/>
     <xs:element name="charges">
         <xs:complexType>
@@ -41,12 +39,9 @@
                         </xs:complexContent>
                     </xs:complexType>
                 </xs:element>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="exportCredit"
-                    type="ChargeType"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="statementCharge"
-                    type="ChargeType"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="marketSupplyCharge"
-                    type="ChargeType"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="exportCredit" type="ChargeType"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="statementCharge" type="ChargeType"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="marketSupplyCharge" type="ChargeType"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -69,14 +64,14 @@
             <xs:element name="tariffBookLeafRange" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="startLeafNbr" type="xs:string"/>
-                        <xs:element name="endLeafNbr" type="xs:string"/>
+                        <xs:element name="startLeafNumber" type="xs:string"/>
+                        <xs:element name="endLeafNumber" type="xs:string"/>
                         <xs:element name="dpsCaseNumber" maxOccurs="unbounded" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element minOccurs="0" name="statementTypeCode" type="xs:string"/>
-            <xs:element name="serviceTierNr" type="xs:int" minOccurs="0">
+            <xs:element name="serviceTierNumber" type="xs:int" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>Tooltip:<br/> 
                             the number for the threshold tier for which the minimum charge is applicable (if any tiered thresholds exist for the rate)<p/>
@@ -85,7 +80,7 @@
                             The number of the tier for which the base charge is applicable (if any tier thresholds exist for the rate).</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="ratePeriodNr" type="xs:int" minOccurs="0"/>
+            <xs:element name="ratePeriodNumber" type="xs:int" minOccurs="0"/>
             <xs:element name="peakType" minOccurs="0">
                 <xs:simpleType>
                     <xs:annotation>

--- a/common_definitions.xsd
+++ b/common_definitions.xsd
@@ -302,8 +302,32 @@ Enumerations simpleType
     </xs:simpleType>
     <xs:simpleType name="PhaseCodeKind">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="AAA"/>
+            <xs:enumeration value="A"/>
+            <xs:enumeration value="AB"/>
             <xs:enumeration value="ABC"/>
+            <xs:enumeration value="ABCN"/>
+            <xs:enumeration value="ABN"/>
+            <xs:enumeration value="AC"/>
+            <xs:enumeration value="ACN"/>
+            <xs:enumeration value="AN"/>
+            <xs:enumeration value="B"/>
+            <xs:enumeration value="BC"/>
+            <xs:enumeration value="BCN"/>
+            <xs:enumeration value="BN"/>
+            <xs:enumeration value="C"/>
+            <xs:enumeration value="CN"/>
+            <xs:enumeration value="N"/>
+            <xs:enumeration value="X"/>
+            <xs:enumeration value="XN"/>
+            <xs:enumeration value="XY"/>
+            <xs:enumeration value="XYN"/>
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="s1"/>
+            <xs:enumeration value="s12"/>
+            <xs:enumeration value="s12N"/>
+            <xs:enumeration value="s1N"/>
+            <xs:enumeration value="s2"/>
+            <xs:enumeration value="s2N"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="SeasonNameKind">
@@ -426,7 +450,13 @@ Enumerations simpleType
     <xs:element name="phases">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="phase" maxOccurs="unbounded"/>
+                <xs:element ref="phase" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:appinfo xml:lang="en">Phase code</xs:appinfo>
+                        <xs:documentation xml:lang="en">Number of wires and specific nominal phases can be deduced from enumeration literal values. For example, ABCN is three-phase, four-wire, s12n (splitSecondary12N) is single-phase, three-wire, and s1n and s2n are single-phase, two-wire.</xs:documentation>
+                        <xs:documentation>source: CIM TC57: https://ontology.tno.nl/IEC_CIM/cim_UsagePoint.phaseCode.html</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/common_definitions.xsd
+++ b/common_definitions.xsd
@@ -301,6 +301,9 @@ Enumerations simpleType
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="PhaseCodeKind">
+        <xs:annotation>
+            <xs:documentation>list of phaseCode values from CIM, source: https://ontology.tno.nl/IEC_CIM/cim_PhaseCode.html</xs:documentation>
+        </xs:annotation>
         <xs:restriction base="xs:string">
             <xs:enumeration value="A"/>
             <xs:enumeration value="AB"/>
@@ -450,17 +453,17 @@ Enumerations simpleType
     <xs:element name="phases">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="phase" maxOccurs="unbounded">
-                    <xs:annotation>
-                        <xs:appinfo xml:lang="en">Phase code</xs:appinfo>
-                        <xs:documentation xml:lang="en">Number of wires and specific nominal phases can be deduced from enumeration literal values. For example, ABCN is three-phase, four-wire, s12n (splitSecondary12N) is single-phase, three-wire, and s1n and s2n are single-phase, two-wire.</xs:documentation>
-                        <xs:documentation>source: CIM TC57: https://ontology.tno.nl/IEC_CIM/cim_UsagePoint.phaseCode.html</xs:documentation>
-                    </xs:annotation>
-                </xs:element>
+                <xs:element ref="phase" maxOccurs="unbounded"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-    <xs:element name="phase" nillable="true" type="PhaseCodeKind"/>
+    <xs:element name="phase" nillable="true" type="PhaseCodeKind">
+        <xs:annotation>
+            <xs:appinfo xml:lang="en">Phase code</xs:appinfo>
+            <xs:documentation xml:lang="en">Phase code value representing phases. from CIM: "Number of wires and specific nominal phases can be deduced from enumeration literal values. For example, ABCN is three-phase, four-wire, s12n (splitSecondary12N) is single-phase, three-wire, and s1n and s2n are single-phase, two-wire."</xs:documentation>
+            <xs:documentation>source: CIM TC57: https://ontology.tno.nl/IEC_CIM/cim_UsagePoint.phaseCode.html</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="scopeOfApplicability" type="ScopeOfApplicabilityType"> </xs:element>
     <xs:element name="statisticKind">
         <xs:simpleType>

--- a/eligibility.xsd
+++ b/eligibility.xsd
@@ -28,14 +28,11 @@
     <xs:complexType name="CriterionType">
         <xs:sequence>
             <xs:element name="criterionKind">
+                <xs:annotation>
+                    <xs:appinfo>The type of eligibility criterion</xs:appinfo>
+                    <xs:documentation>The type of eligibility criterion per included enumeration list</xs:documentation>
+                </xs:annotation>
                 <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            the type of eligibility criteria (e.g. "program_enrollment ", "pilot_participation") <p/>
-                            
-                            Comment:<br/> 
-                            enum with possible values: "program_enrollment ", "pilot_participation"</xs:documentation>
-                    </xs:annotation>
                     <xs:restriction base="xs:string">
                         <xs:maxLength value="40"/>
                         <xs:enumeration value="ServiceProvision"/>
@@ -55,16 +52,14 @@
             <xs:element minOccurs="0" ref="phases"/>
             <xs:element name="name" type="xs:string"> </xs:element>
             <xs:element name="description">
+                <xs:annotation>
+                    <xs:appinfo>A description of the rules for fulfilling this eligibility criteria</xs:appinfo>
+                    <xs:documentation>A description of the rules for fulfilling this eligibility criteria</xs:documentation>
+                </xs:annotation>
                 <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            a text description of the rules for fulfilling this eligibility criteria<p/>
-                            
-                            Comment:<br/> 
-                            a text description of the rules for fulfilling this criteria</xs:documentation>
-                    </xs:annotation>
                     <xs:restriction base="xs:string">
                         <xs:maxLength value="2000"/>
+                        <xs:minLength value="20"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>

--- a/rate_plan_modifiers.xsd
+++ b/rate_plan_modifiers.xsd
@@ -42,7 +42,7 @@
                 </xs:simpleType>
             </xs:element>
             <xs:element default="" name="modifierName" type="xs:string"/>
-            <xs:element name="UtilityPscNbr">
+            <xs:element name="UtilityPscNumber">
                 <xs:simpleType>
                     <xs:restriction base="xs:int">
                         <xs:minInclusive value="0"/>

--- a/rate_plans.xsd
+++ b/rate_plans.xsd
@@ -39,7 +39,6 @@
                     <xs:restriction base="xs:string">
                         <xs:maxLength value="3"/>
                         <xs:enumeration value="AGR"/>
-                        <xs:enumeration value="AGR"/>
                         <xs:enumeration value="CEI"/>
                         <xs:enumeration value="LBR"/>
                         <xs:enumeration value="NGG"/>

--- a/service_tier_thresholds.xsd
+++ b/service_tier_thresholds.xsd
@@ -19,7 +19,7 @@
     <xs:complexType name="ServiceTierThresholdType">
         <xs:sequence>
             <xs:element name="effectiveInterval" type="DateIntervalType"/>
-            <xs:element name="serviceTierNr" type="xs:int"/>
+            <xs:element name="serviceTierNumber" type="xs:int"/>
             <xs:element ref="seasonName"> </xs:element>
             <xs:element name="measurementSpecification" type="MeasureType"/>
             <xs:element name="min_qty" type="xs:int"> </xs:element>

--- a/tariff_books.xsd
+++ b/tariff_books.xsd
@@ -94,14 +94,14 @@
                 <xs:element name="tariffBookLeafRange" maxOccurs="unbounded">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="startLeafNbr" type="xs:string"/>
-                            <xs:element name="endLeafNbr" type="xs:string"/>
+                            <xs:element name="startLeafNumber" type="xs:string"/>
+                            <xs:element name="endLeafNumber" type="xs:string"/>
                             <xs:element name="dpsCaseNumber" maxOccurs="unbounded" type="xs:string"/>
                             <xs:element name="receivedDate" type="xs:date"/>
                             <xs:element name="initialEffectiveDate" type="xs:date"/>
                             <xs:element name="effectiveDate" type="xs:date"/>
-                            <xs:element name="revisionNbr" type="xs:int"/>
-                            <xs:element name="supersedingRevision"/>
+                            <xs:element name="revisionNumber" type="xs:int"/>
+                            <xs:element name="supersedingRevisionNumber"/>
                             <xs:element name="status">
                                 <xs:simpleType>
                                     <xs:restriction base="xs:string">

--- a/time_of_use_periods.xsd
+++ b/time_of_use_periods.xsd
@@ -19,7 +19,7 @@
     <xs:complexType name="TimeOfUsePeriodType">
         <xs:sequence>
             <xs:element name="effectivePeriod" type="DateIntervalType"/>
-            <xs:element name="RatePeriodNrNonHolidays">
+            <xs:element name="RatePeriodNumberNonHolidays">
                 <xs:simpleType>
                     <xs:annotation>
                         <xs:documentation>Tooltip:<br/> 
@@ -33,7 +33,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="RatePeriodNrHolidays" nillable="false">
+            <xs:element name="RatePeriodNumberHolidays" nillable="false">
                 <xs:simpleType>
                     <xs:annotation>
                         <xs:documentation>Tooltip:<br/> 


### PR DESCRIPTION
updated annotations
standardized field names containing "Number" to have "Number" and not "Nbr" or "Nr"