### PR TITLE
tweaks to simplify and remove redundancy in tariffBook file

### DIFF
--- a/common_definitions.xsd
+++ b/common_definitions.xsd
@@ -211,9 +211,37 @@ If a suffix is added (ex.: "SC1TOU1" ) this field shall be populated with just t
     </xs:complexType>
     <xs:complexType name="DocumentationType">
         <xs:sequence>
-            <xs:element name="iedrOrgAbbreviation" type="xs:string"
-                minOccurs="0"/>
-            <xs:element minOccurs="0" name="dpsUtilityPscNumber">
+            <xs:element minOccurs="0" name="parentOrgIedrAbbreviation">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="3"/>
+                        <xs:minLength value="3"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element minOccurs="0" name="parentOrgName"/>
+            <xs:element name="iedrOrgAbbreviation" type="xs:string"/>
+            <xs:element minOccurs="0" name="iedrUtilityUserFacingName"/>
+            <xs:element minOccurs="0" name="tariffUtilityName">
+                <xs:simpleType>
+                    <xs:annotation>
+                        <xs:documentation>Tooltip:<br/> 
+                            the name of the utility provider in the tariff book with which this rate plan is associated<p/>
+                            
+                            Comment:<br/> 
+                            Name of utility provider</xs:documentation>
+                    </xs:annotation>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="100"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element minOccurs="0" name="dpsCompanyId" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>populated by IEDR platform</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element minOccurs="0" name="dpsPscNumber">
                 <xs:simpleType>
                     <xs:restriction base="xs:int">
                         <xs:totalDigits value="3"/>

--- a/eligibility.xsd
+++ b/eligibility.xsd
@@ -95,8 +95,8 @@
                 </xs:simpleType>
             </xs:element>
             <xs:element name="name" type="xs:string"> </xs:element>
-            <xs:element name="limitMeasureSpecification" type="MeasureType"/>
             <xs:element name="limitValue" type="xs:int"> </xs:element>
+            <xs:element name="limitMeasureSpecification" type="MeasureType"/>
             <xs:element name="description">
                 <xs:simpleType>
                     <xs:annotation>

--- a/rate_plans.xsd
+++ b/rate_plans.xsd
@@ -29,7 +29,7 @@
                 </xs:simpleType>
             </xs:element>
             <xs:element minOccurs="0" name="parentOrgName"/>
-            <xs:element name="ratePlanIedrOrgAbbreviation" nillable="false">
+            <xs:element name="iedrOrgAbbreviation" nillable="false">
                 <xs:simpleType>
                     <xs:annotation>
                         <xs:documentation>Tooltip:<br/> 
@@ -59,8 +59,8 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="iedrUtilityUserFacingName"/>
-            <xs:element name="tariffUtilityName">
+            <xs:element name="iedrUtilityUserFacingName" minOccurs="0"/>
+            <xs:element name="tariffUtilityName" minOccurs="0">
                 <xs:simpleType>
                     <xs:annotation>
                         <xs:documentation>Tooltip:<br/> 
@@ -74,30 +74,18 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="dpsCompanyId" type="xs:string">
+            <xs:element name="dpsCompanyId" type="xs:string" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>populated by IEDR platform</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="dpsPscNumber" type="xs:string"> </xs:element>
-            <xs:element name="serviceClassNumber" type="xs:int"/>
-            <xs:element name="serviceClassName" type="xs:string"/>
-            <xs:element name="rateCode" type="xs:string"/>
-            <xs:element name="rateName"/>
-            <xs:element minOccurs="0" name="initialDateEffective"/>
-            <xs:element name="dateEffective" nillable="false">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            the date that the rate plan went or will go into effect<p/>
-                            
-                            Comment:<br/> 
-                            - Date that the rate plan went into effect
-                            - Date formatted in either basic or extended ISO compliant format as “YYYYMMDD” or “YYYY-MM-DD," respectively. </xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:date"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
+            <xs:element name="dpsPscNumber" type="xs:string" minOccurs="0"> </xs:element>
+            <xs:element name="serviceClassNumber" type="xs:int" minOccurs="0"/>
+            <xs:element name="serviceClassName" type="xs:string" minOccurs="0"/>
+            <xs:element name="rateCode" type="xs:string" minOccurs="0"/>
+            <xs:element name="rateName" minOccurs="0"/>
+            <xs:element minOccurs="0" name="initialEffectiveDate"/>
+            <xs:element name="effectiveDate" nillable="false" type="xs:date"> </xs:element>
             <xs:element name="dateCancellation" nillable="true" minOccurs="0">
                 <xs:simpleType>
                     <xs:annotation>
@@ -184,7 +172,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="tariffDpsCaseNumber" maxOccurs="unbounded" type="xs:string"> </xs:element>
+            <xs:element name="dpsCaseNumber" maxOccurs="unbounded" type="xs:string" minOccurs="0"> </xs:element>
             <xs:element name="ratePlanHasRetailSupply" minOccurs="0">
                 <xs:simpleType>
                     <xs:annotation>


### PR DESCRIPTION
consistent naming for IEDROrgAbbreviation
moved value for limit up in order
made data elements in rate_plans redundant in tariffBook file optional