### PR TITLE
v0.99.6-dev updates

### DIFF
--- a/common_definitions.xsd
+++ b/common_definitions.xsd
@@ -42,24 +42,24 @@ Complex Types
 -->
     <xs:complexType name="ConstraintVariableType">
         <xs:sequence>
-            <xs:element name="customerClasses" minOccurs="0">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" name="customerClass"
-                            type="CustomerClassKind"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
             <xs:element name="serviceClasses" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation>Applicable service classes, eg. "1" for service Class 1. Use "All" if applicable to all service classes.
-
+                    <xs:appinfo>Applicable Service Classes</xs:appinfo>
+                    <xs:documentation>Applicable service classes, eg. "1" for service Class 1. Use either an integer or "All" if applicable to all service classes.
 If a suffix is added (ex.: "SC1TOU1" ) this field shall be populated with just the number for the parent service class. The suffix shall made available separately in "rateCodes"</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" name="serviceClass"
-                            type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" name="serviceClass">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="serviceClassNumber"
+                                        type="xs:string"/>
+                                    <xs:element name="serviceClassName"
+                                        type="xs:string"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -69,14 +69,22 @@ If a suffix is added (ex.: "SC1TOU1" ) this field shall be populated with just t
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" name="rateCode"
-                            type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" name="rateCode">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="rateCodeNumber"
+                                        type="xs:int"/>
+                                    <xs:element name="rateName" type="xs:string"
+                                    />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element form="qualified" minOccurs="0" name="ratePlans">
                 <xs:annotation>
-                    <xs:documentation>Applicable ratePlanCodeUnique values</xs:documentation>
+                    <xs:documentation>Applicable ratePlanCodeUnique values. Not used when ConstrainVariableType is used within RatePlanType occurrences.</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
@@ -96,6 +104,18 @@ If a suffix is added (ex.: "SC1TOU1" ) this field shall be populated with just t
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="customerClasses" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo>Applicable customer classes</xs:appinfo>
+                    <xs:documentation>Applicable customer classes</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" name="customerClass"
+                            type="CustomerClassKind"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="customRatePlanAttribute" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>Flexible options for rate plan attributes by which to filter rate plans for applicability</xs:documentation>
@@ -107,8 +127,24 @@ If a suffix is added (ex.: "SC1TOU1" ) this field shall be populated with just t
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element ref="customerEntities"/>
+            <xs:element ref="dwellingScenario"/>
+            <xs:element minOccurs="0" ref="endUses">
+                <xs:annotation>
+                    <xs:appinfo>Applicable end uses</xs:appinfo>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:element>
+            <xs:element minOccurs="0" ref="equipmentScenario"/>
+            <xs:element minOccurs="0" ref="onSiteGenerationScenario"/>
             <xs:element minOccurs="0" ref="phases"/>
-            <xs:element minOccurs="0" name="season"/>
+            <xs:element minOccurs="0" name="season">
+                <xs:annotation>
+                    <xs:appinfo>Applicable season</xs:appinfo>
+                    <xs:documentation>Applicable season</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element minOccurs="0" ref="serviceProvisionScenario"/>
             <xs:element minOccurs="0" name="territories">
                 <xs:complexType>
                     <xs:sequence>
@@ -316,41 +352,59 @@ Enumerations simpleType
 
     <xs:simpleType name="CustomerClassKind">
         <xs:annotation>
-            <xs:documentation>Tooltip:<br/> 
-                    the type of customer that the rate plan applies to such as residential, commercial, industrial, lighting<p/>
-                    
-                    Comment:<br/> 
-                    The type of customer that the tariff applies to such as residential, commercial, industrial, lighting</xs:documentation>
+            <xs:appinfo>The type of applicable customer class</xs:appinfo>
+            <xs:documentation>The type of applicable customer class</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
             <xs:maxLength value="255"/>
             <xs:enumeration value="Commercial"/>
-            <xs:enumeration value=" Commercial Large"/>
-            <xs:enumeration value="Distributed Generation"/>
+            <xs:enumeration value="CommercialLarge"/>
+            <xs:enumeration value="DistributedGeneration"/>
             <xs:enumeration value="Industrial"/>
             <xs:enumeration value="Interruptible"/>
             <xs:enumeration value="Lighting"/>
-            <xs:enumeration value="Natural Gas Vehicle"/>
-            <xs:enumeration value="Non-residential"/>
+            <xs:enumeration value="NaturalGasVehicle"/>
+            <xs:enumeration value="NonResidential"/>
             <xs:enumeration value="Religious"/>
             <xs:enumeration value="Residential"/>
-            <xs:enumeration value="Street Lighting"/>
-            <xs:enumeration value="Time of Use"/>
+            <xs:enumeration value="StreetLighting"/>
             <xs:enumeration value="Transmission"/>
-            <xs:enumeration value="Transmission Or Substation"/>
+            <xs:enumeration value="Substation"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="EndUseKind">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Heating"/>
+            <xs:enumeration value="NonHeating"/>
+            <xs:enumeration value="NotExclusivelyIndividualResidence"/>
+            <xs:enumeration value="Heating"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="EquipmentKind">
+        <xs:annotation>
+            <xs:appinfo>Applicable equipment scenarios</xs:appinfo>
+            <xs:documentation/>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="OnSiteGeneration"/>
+            <xs:enumeration value="PEV"/>
+            <xs:enumeration value="AMIMeter"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="MeasurementKind">
         <xs:annotation>
-            <xs:documentation>Tooltip:<br/> 
-                
-                The type of measurement, Naming and enumeration options are in alignment with those from Green Button Connect
+            <xs:appinfo>The type of measurement, naming and enumeration options contain a subset those used in CIM and Green Button connect</xs:appinfo>
+            <xs:documentation>
+                The type of measurement, naming and enumeration options contain a subset those used in the Common Information Profile (CIM) and Green Button (NAESB REQ.21 – Energy Services Provider Interface).
                 Element naming is aligned with the CIM semantic model: https://ontology.tno.nl/cerise/cim-profile/cim_ReadingType.measurementKind.html
-                OWL ontology at: https://ontology.tno.nl/IEC_CIM.ttl
-                
-                Identifies "what" is being measured, as refinement of 'commodity'. When combined with 'unit', it provides detail to the unit of measure. For example, 'energy' with a unit of measure of 'kWh' indicates to the user that active energy is being measured, while with 'kVAh' or 'kVArh', it indicates apparent energy and reactive energy, respectively. 'power' can be combined in a similar way with various power units of measure: Distortion power ('distortionVoltAmperes') with 'kVA' is different from 'power' with 'kVA'.</xs:documentation>
+                OWL ontology at: https://ontology.tno.nl/IEC_CIM.ttl<br/> </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
+            <xs:enumeration value="apparentPower">
+                <xs:annotation>
+                    <xs:documentation>Not available in CIM/GBC, where "energy" is used in combination with a unit of measure to express reactive and apparent power</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="apparentPowerFactor"/>
             <xs:enumeration value="batteryCarryover"/>
             <xs:enumeration value="batteryVoltage"/>
@@ -364,13 +418,24 @@ Enumerations simpleType
             <xs:enumeration value="power"/>
             <xs:enumeration value="powerFactor"/>
             <xs:enumeration value="powerQuality"/>
+            <xs:enumeration value="reactivePower">
+                <xs:annotation>
+                    <xs:documentation>Not available in CIM/GBC, where "energy" is used in combination with a unit of measure to express reactive and apparent power</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="voltage"/>
             <xs:enumeration value="volumetricFlow"/>
             <xs:enumeration value=""/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:simpleType name="OnSiteGenerationKind">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value=""/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:simpleType name="PhaseCodeKind">
         <xs:annotation>
+            <xs:appinfo>list of phaseCode values from CIM, source: https://ontology.tno.nl/IEC_CIM/cim_PhaseCode.html</xs:appinfo>
             <xs:documentation>list of phaseCode values from CIM, source: https://ontology.tno.nl/IEC_CIM/cim_PhaseCode.html</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
@@ -420,10 +485,10 @@ Enumerations simpleType
             <xs:enumeration value="Steam"/>
         </xs:restriction>
     </xs:simpleType>
-    <xs:simpleType name="VoltageKind">
+    <xs:simpleType name="ServiceProvisionKind">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="low"/>
-            <xs:enumeration value="high"/>
+            <xs:enumeration value="Interruptible"/>
+            <xs:enumeration value="Standby"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="UnitSymbolKind">
@@ -595,11 +660,18 @@ Enumerations simpleType
     </xs:simpleType>
     <xs:simpleType name="ValueInclusionKind">
         <xs:annotation>
-            <xs:documentation>If the value defines a limit included in the limit <!--(i.e. "=", "<=", or ">=")-->"inclusive" shall be used,If the value defines a limit included in the limit, "exclusive" shall be used<!--(i.e. "<" or ">")--> if only values smaller or greater </xs:documentation>
+            <xs:appinfo>denotes whether value is or is not considered to be included in case the value indicates a service or other threshold or limit</xs:appinfo>
+            <xs:documentation>denotes whether value is or is not considered to be included in case the value indicates a service or other threshold or limit. If the value defines a limit included in the limit <!--(i.e. "=", "<=", or ">=")-->"inclusive" shall be used,If the value defines a limit included in the limit, "exclusive" shall be used<!--(i.e. "<" or ">")--> if only values smaller or greater </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
             <xs:enumeration value="inclusive"/>
             <xs:enumeration value="exclusive"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="VoltageKind">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="low"/>
+            <xs:enumeration value="high"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:element name="calcIntervalKind">
@@ -624,6 +696,50 @@ Enumerations simpleType
             </xs:restriction>
         </xs:simpleType>
     </xs:element>
+    <xs:element name="dwellingScenario">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dwelling"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="dwelling" type="DwellingKind"/>
+    <xs:element name="customerEntities">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="customerEntity"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="customerEntity" type="EntityKind"/>
+    <xs:element name="endUses">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="endUse"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="endUse" type="EndUseKind"/>
+    <xs:element name="equipmentScenario">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="equipment"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="equipment" type="EquipmentKind"/>
+    <xs:element name="onSiteGenerationScenario">
+        <xs:annotation>
+            <xs:appinfo>Applicable onsite generation scenario</xs:appinfo>
+            <xs:documentation/>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="onSiteGeneration"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="onSiteGeneration" type="OnSiteGenerationKind"/>
     <xs:element name="phases">
         <xs:complexType>
             <xs:sequence>
@@ -639,16 +755,24 @@ Enumerations simpleType
         </xs:annotation>
     </xs:element>
     <xs:element name="scopeOfApplicability" type="ScopeOfApplicabilityType"> </xs:element>
+    <xs:element name="serviceProvisionScenario">
+        <xs:annotation>
+            <xs:appinfo>Applicable service provision</xs:appinfo>
+            <xs:documentation>Applicable service provision</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="serviceProvision"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="serviceProvision" type="ServiceProvisionKind"/>
     <xs:element name="statisticKind">
+        <xs:annotation>
+            <xs:appinfo>The statistic type of the measurement</xs:appinfo>
+            <xs:documentation>The statistic type of the measurement</xs:documentation>
+        </xs:annotation>
         <xs:simpleType>
-            <xs:annotation>
-                <xs:documentation>Tooltip:<br/> 
-                    the statistic type of the eligibility limit to de minimum or maximum limit (e.g. "min", "max", "avg") limits are inclusive. i.e. a minimum of 40kW means sa customer with 40 kW can be on the rate plan<p/>
-                    
-                    Comment:<br/> 
-                    the statistic type of the eligibility limit to de minimum or maximum limit (e.g. "min", "max", "avg")
-                    limits are inclusive. i.e. a minimum of 40kW means a customer with 40 kW can be on the rate plan</xs:documentation>
-            </xs:annotation>
             <xs:restriction base="xs:string">
                 <xs:maxLength value="3"/>
                 <xs:enumeration value="min"/>
@@ -670,5 +794,32 @@ Enumerations simpleType
             <xs:documentation xml:lang="en">Enumeration describing the type of applicable voltage (also called "tension"). Where applicable, numeric voltage limits applicable to the rate plan or rate plan modifiers associated with a given charge shall be defined further in each of its respective "eligibility">"limit" elements</xs:documentation>
         </xs:annotation>
     </xs:element>
-    <xs:element name="seasonName" type="SeasonNameKind"/>
+    <xs:element name="seasonName" type="SeasonNameKind">
+        <xs:annotation>
+            <xs:appinfo>Season Name</xs:appinfo>
+            <xs:documentation>Season Name</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:simpleType name="DwellingKind">
+        <xs:annotation>
+            <xs:appinfo>List of dwelling types</xs:appinfo>
+            <xs:documentation>List of dwelling types</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Multifamily"/>
+            <xs:enumeration value="SingleFamily"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="EntityKind">
+        <xs:annotation>
+            <xs:appinfo>Applicable entity type</xs:appinfo>
+            <xs:documentation>Applicable entity type</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NonProfit"/>
+            <xs:enumeration value="Government"/>
+            <xs:enumeration value="CommunityBasedOrganization"/>
+            <xs:enumeration value="PrivateOrganization"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/eligibility.xsd
+++ b/eligibility.xsd
@@ -4,15 +4,14 @@
     <xs:element name="eligibility">
         <xs:complexType>
             <xs:sequence>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="criterion">
+                <xs:element name="enrollments">
                     <xs:complexType>
-                        <xs:complexContent>
-                            <xs:extension base="CriterionType">
-                                <xs:attribute ref="ratePlanCodeUnique" use="optional"/>
-                                <xs:attribute ref="isReplacementRecord" use="optional"/>
-                                <xs:attribute ref="IsDeletedRecord" use="optional"/>
-                            </xs:extension>
-                        </xs:complexContent>
+                        <xs:sequence>
+                            <xs:element maxOccurs="unbounded" name="enrollment"
+                                type="EnrollmentType"/>
+                            <xs:element name="priorEnrollmentScenario" type="ConstraintVariableType"
+                            />
+                        </xs:sequence>
                     </xs:complexType>
                 </xs:element>
                 <xs:element maxOccurs="unbounded" minOccurs="0" name="limit">
@@ -27,34 +26,27 @@
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>
+            <xs:attribute ref="IsDeletedRecord" use="optional"/>
+            <xs:attribute ref="isReplacementRecord" use="optional"/>
+            <xs:attribute ref="ratePlanCodeUnique" use="optional"/>
         </xs:complexType>
     </xs:element>
-    <xs:complexType name="CriterionType">
+    <xs:complexType name="EnrollmentType">
         <xs:sequence>
-            <xs:element name="criterionKind">
-                <xs:annotation>
-                    <xs:appinfo>The type of eligibility criterion</xs:appinfo>
-                    <xs:documentation>The type of eligibility criterion per included enumeration list</xs:documentation>
-                </xs:annotation>
+            <xs:element name="enrollmentKind">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:maxLength value="40"/>
-                        <xs:enumeration value="ServiceProvision"/>
-                        <xs:enumeration value="RateProvision"/>
-                        <xs:enumeration value="EndUse"/>
-                        <xs:enumeration value="CustomerClass"/>
-                        <xs:enumeration value="Equipment"/>
                         <xs:enumeration value="ProgramEnrollment"/>
-                        <xs:enumeration value="Applicability"/>
                         <xs:enumeration value="VoluntaryEnrollment"/>
-                        <xs:enumeration value="ServiceClass"/>
                         <xs:enumeration value="MandatoryEnrollment"/>
-                        <xs:enumeration value="Phases"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element minOccurs="0" ref="phases"/>
-            <xs:element name="name" type="xs:string"> </xs:element>
+            <xs:element name="name" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Data provider's own string with naming for enrollment</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="description">
                 <xs:annotation>
                     <xs:appinfo>A description of the rules for fulfilling this eligibility criteria</xs:appinfo>

--- a/rate_plan_data_output.xsd
+++ b/rate_plan_data_output.xsd
@@ -51,30 +51,32 @@
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
-                <xs:element minOccurs="0" ref="scenarioInputSettings"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="scenarioInputSettings">
-        <xs:annotation>
-            <xs:documentation>Each ratePlanScenario may have one or multiple "branches" of charge options which depend on attributes specific to each scenario instance. Examples are: parameters determined by the utility (e.g. contracted electric demand) or by the scenanrio location falling within a rate plan territory.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element minOccurs="0" ref="scopeOfApplicability"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="icapTag">
+                <xs:element name="scenarioInputSettings">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">Container for all parameters that define choices between rate plan and modifier options or charges associated within each option. Each ratePlanScenario may have one or multiple "branches" of charge options which depend on attributes specific to each scenario instance. Examples are: parameters determined by the utility (e.g. contracted electric demand) or by the scenanrio location falling within a rate plan territory.</xs:documentation>
+                    </xs:annotation>
                     <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="icapTagValidPeriod" type="DateIntervalType"/>
-                            <xs:element name="icapTagValue" type="xs:int"/>
-                            <xs:element name="icapTagValueDefinition" type="MeasureType"/>
-                        </xs:sequence>
+                        <xs:complexContent>
+                            <xs:extension base="ConstraintVariableType">
+                                <xs:sequence>
+                                    <xs:element maxOccurs="unbounded" minOccurs="0" name="icapTag">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="icapTagValidPeriod"
+                                                  type="DateIntervalType"/>
+                                                <xs:element name="icapTagValue" type="xs:int"/>
+                                                <xs:element name="icapTagValueDefinition"
+                                                  type="MeasureType"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:extension>
+                        </xs:complexContent>
                     </xs:complexType>
                 </xs:element>
-                <xs:element minOccurs="0" name="territoryId" type="xs:string" maxOccurs="unbounded"/>
-                <xs:element minOccurs="0" name="equipment" type="xs:string" maxOccurs="unbounded"/>
-                <xs:element minOccurs="0" ref="phase" maxOccurs="unbounded"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
+
 </xs:schema>

--- a/rate_plans.xsd
+++ b/rate_plans.xsd
@@ -20,73 +20,208 @@
     </xs:element>
     <xs:complexType name="RatePlanType">
         <xs:sequence>
-            <xs:element minOccurs="0" name="parentOrgIedrAbbreviation">
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="3"/>
-                        <xs:minLength value="3"/>
-                    </xs:restriction>
-                </xs:simpleType>
+            <xs:element name="utilityInfo">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="parentOrgIedrAbbreviation">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:maxLength value="3"/>
+                                    <xs:minLength value="3"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element minOccurs="0" name="parentOrgName"/>
+                        <xs:element name="iedrOrgAbbreviation" nillable="false">
+                            <xs:annotation>
+                                <xs:appinfo>a three letter abbreviation for the utility or data provider assigned for the IEDR platform</xs:appinfo>
+                                <xs:documentation>a three letter abbreviation for the utility or data provider assigned for the IEDR platform</xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:maxLength value="3"/>
+                                    <xs:enumeration value="AGR"/>
+                                    <xs:enumeration value="CEI"/>
+                                    <xs:enumeration value="LBR"/>
+                                    <xs:enumeration value="NGG"/>
+                                    <xs:enumeration value="NFG"/>
+                                    <xs:enumeration value="PLI"/>
+                                    <xs:enumeration value="DPS"/>
+                                    <xs:enumeration value="NRD"/>
+                                    <xs:enumeration value="NYE"/>
+                                    <xs:enumeration value="RGE"/>
+                                    <xs:enumeration value="CED"/>
+                                    <xs:enumeration value="ORU"/>
+                                    <xs:enumeration value="KNY"/>
+                                    <xs:enumeration value="KLI"/>
+                                    <xs:enumeration value="NIM"/>
+                                    <xs:enumeration value="LPA"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="iedrUtilityUserFacingName" minOccurs="0"/>
+                        <xs:element name="dpsPscNumber" type="xs:string" minOccurs="0"> </xs:element>
+                        <xs:element name="tariffUtilityName" minOccurs="0">
+                            <xs:annotation>
+                                <xs:appinfo>The  name of the utility provider as it appears in the tariff book with which this rate plan is associated</xs:appinfo>
+                                <xs:documentation>The  name of the utility provider as it appears in the tariff book with which this rate plan is associated</xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:maxLength value="100"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="dpsCompanyId" type="xs:string" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation>Id used in ET DPS system populated by IEDR platform and used to generate URL linkage for source data references</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
             </xs:element>
-            <xs:element minOccurs="0" name="parentOrgName"/>
-            <xs:element name="iedrOrgAbbreviation" nillable="false">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            a three letter abbreviation for the utility assigned for the IEDR platform (.e.g New York State Electric &amp; Gas Corporation is NYE; Consolidated Edison Company of New York, Inc is CED)<p/>
-                            
-                            Comment:<br/> 
-                            abbreviation for utility organization assigned for IEDR (see "iedr_utilities"). Populated at either parent data provider organization or sub-utility level.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="3"/>
-                        <xs:enumeration value="AGR"/>
-                        <xs:enumeration value="CEI"/>
-                        <xs:enumeration value="LBR"/>
-                        <xs:enumeration value="NGG"/>
-                        <xs:enumeration value="NFG"/>
-                        <xs:enumeration value="PLI"/>
-                        <xs:enumeration value="DPS"/>
-                        <xs:enumeration value="NRD"/>
-                        <xs:enumeration value="NYE"/>
-                        <xs:enumeration value="RGE"/>
-                        <xs:enumeration value="CED"/>
-                        <xs:enumeration value="ORU"/>
-                        <xs:enumeration value="KNY"/>
-                        <xs:enumeration value="KLI"/>
-                        <xs:enumeration value="NIM"/>
-                        <xs:enumeration value="LPA"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="iedrUtilityUserFacingName" minOccurs="0"/>
-            <xs:element name="tariffUtilityName" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            the name of the utility provider in the tariff book with which this rate plan is associated<p/>
-                            
-                            Comment:<br/> 
-                            Name of utility provider</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="100"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="dpsCompanyId" type="xs:string" minOccurs="0">
+            <xs:element name="service" nillable="false" type="ServiceKind"> </xs:element>
+            <xs:element name="ratePlanName">
                 <xs:annotation>
-                    <xs:documentation>populated by IEDR platform</xs:documentation>
+                    <xs:appinfo>The name of the rate plan</xs:appinfo>
+                    <xs:documentation>The name of the rate plan. Note that the rate plan name may not explicitly or exactly appear as its own distinct "rate" in the tariff book. Naming may be derived from the names of groups of charges listed in tariff documentation.</xs:documentation>
                 </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="255"/>
+                        <xs:whiteSpace value="collapse"/>
+                    </xs:restriction>
+                </xs:simpleType>
             </xs:element>
-            <xs:element name="dpsPscNumber" type="xs:string" minOccurs="0"> </xs:element>
-            <xs:element name="serviceClassNumber" type="xs:int" minOccurs="0"/>
-            <xs:element name="serviceClassName" type="xs:string" minOccurs="0"/>
-            <xs:element name="rateCode" type="xs:string" minOccurs="0"/>
-            <xs:element name="rateName" minOccurs="0"/>
+            <xs:element name="applicability" type="ConstraintVariableType"/>
+            <xs:element name="ratePlanDescription">
+                <xs:annotation>
+                    <xs:appinfo>A brief text description of the rate plan describing its most important applicability context, enrollment criteria, and eligibility limits</xs:appinfo>
+                    <xs:documentation>A brief text description of the rate plan describing its most important applicability context, enrollment criteria, and eligibility limits</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="2000"/>
+                        <xs:whiteSpace value="collapse"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="dpsCaseNumber" maxOccurs="unbounded" type="xs:string"> </xs:element>
+            <xs:element name="ratePlanFeatures">
+                <xs:annotation>
+                    <xs:appinfo>List of "tags" with boolean values used for grouping, filtering, and data validation purposes</xs:appinfo>
+                    <xs:documentation>List of "tags" with boolean values used for grouping, filtering, and data validation purposes</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="ratePlanHasDemandCharges">
+                            <xs:annotation>
+                                <xs:appinfo>Boolean indicating whether the rate plan includes Demand Charges</xs:appinfo>
+                                <xs:documentation>Boolean indicating whether the rate plan includes Demand Charges</xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:boolean"> </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ratePlanHasIcapTag">
+                            <xs:annotation>
+                                <xs:appinfo>Boolean indicating whether the rate plan calculation is subject to the ICAP tag of a given customer </xs:appinfo>
+                                <xs:documentation>Boolean indicating whether the rate plan calculation is subject to the ICAP tag of a given customer </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:boolean"> </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ratePlanHasReactivePower">
+                            <xs:annotation>
+                                <xs:appinfo>Boolean indicating whether the rate plan includes Reactive Power Charges</xs:appinfo>
+                                <xs:documentation>oolean indicating whether the rate plan includes Reactive Power Charges</xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:boolean"> </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ratePlanHasRetailSupply">
+                            <xs:annotation>
+                                <xs:appinfo>Boolean indicating whether the rate plan is for only distribution service vs. distribution and supply service with ESCO retail supply</xs:appinfo>
+                                <xs:documentation>oolean indicating whether the rate plan is for only distribution service vs. distribution and supply service with ESCO retail supply</xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:boolean"> </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ratePlanHasTieredBlocks">
+                            <xs:annotation>
+                                <xs:appinfo>Boolean indicating whether the rate plan includes tiered rates for blocks of service, also known as "baseline allowance"</xs:appinfo>
+                                <xs:documentation>Boolean indicating whether the rate plan includes tiered rates for blocks of service, also known as "baseline allowance"</xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:boolean"> </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ratePlanHasTimeOfUsePricing">
+                            <xs:annotation>
+                                <xs:appinfo>Boolean indicating whether the rate plan includes Time of Use (TOU) Pricing</xs:appinfo>
+                                <xs:documentation>oolean indicating whether the rate plan includes Time of Use (TOU) Pricing</xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:boolean"> </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+
+                        <xs:element name="ratePlanIsRateRider">
+                            <xs:annotation>
+                                <xs:appinfo>Boolean indicating whether the rate plan is defined in the tariff book or a rider to the tariff book</xs:appinfo>
+                                <xs:documentation>Boolean indicating whether the rate plan is defined in the tariff book or a rider to the tariff book</xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:boolean"> </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="numberOfRatePeriods" nillable="true">
+                <xs:annotation>
+                    <xs:appinfo/>
+                    <xs:documentation/>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:annotation>
+                        <xs:appinfo>The number of rate periods associated with
+                            the rate plan, counting 1 if no separate thresholds or rates exist for winter and summer. If rates do differ seasonally or more granularly, this is the count of timeOfUsePeriods entries, which shall be equal to the number of unique combinations of seasonName and
+                            weekday type combination valid during a given effective period for this rate plan.</xs:appinfo>
+                        <xs:documentation>TThe number of rate periods associated with
+                            the rate plan, counting 1 if no separate thresholds or rates exist for winter and summer. If rates do differ seasonally or more granularly, this is the count of timeOfUsePeriods entries, which shall be equal to the number of unique combinations of seasonName and
+                            weekday type combination valid during a given effective period for this rate plan. For example: the correct value is "6" if there are 3 time of use periods (off
+                            peak/base/peak), two seasons winter and summer, and no separate rates for weekends. If separate weekend rates do exist for each of the three time of use periods there will be 6 time of use periods per season and the correct value is "12" for winter and summer combined.
+                            This value is used to inform variables expected to be used in cost modeling and scheduling of devices that operate (turn on/off, charge, import/export) based on time of use
+                            schedules.</xs:documentation>
+                    </xs:annotation>
+                    <xs:restriction base="xs:int">
+                        <xs:totalDigits value="2"/>
+                        <xs:minExclusive value="0"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="ratePlanTariffId" nillable="true" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo>Identifier used by the utility to refer to the tariff, rate, rate plan, arte plan modifier, or their subcomponents.</xs:appinfo>
+                    <xs:documentation>Utility maintained identifier used by the utility to refer to a tariff or part of a tariff with which this rate plan is associated.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="50"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="effectivePeriod" type="DateIntervalType"/>
             <xs:element minOccurs="0" name="initialEffectiveDate"/>
-            <xs:element name="effectiveDate" nillable="false" type="xs:date"> </xs:element>
             <xs:element name="dateCancellation" nillable="true" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo/>
+                    <xs:documentation/>
+                </xs:annotation>
                 <xs:simpleType>
                     <xs:annotation>
                         <xs:documentation>Tooltip:<br/> 
@@ -100,6 +235,10 @@
                 </xs:simpleType>
             </xs:element>
             <xs:element name="dateDraftUpdate" nillable="true" minOccurs="0">
+                <xs:annotation>
+                    <xs:appinfo/>
+                    <xs:documentation/>
+                </xs:annotation>
                 <xs:simpleType>
                     <xs:annotation>
                         <xs:documentation>Tooltip:<br/> 
@@ -110,169 +249,6 @@
                             - Date formatted in either basic or extended ISO compliant format as “YYYYMMDD” or “YYYY-MM-DD," respectively. </xs:documentation>
                     </xs:annotation>
                     <xs:restriction base="xs:date"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanTariffId" nillable="true" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            an identifier used by the utility to refer to the tariff with which this rate plan is associated<p/>
-                            
-                            Comment:<br/> 
-                            identifier used by the utility to refer to the tariff or rate plan</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="50"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanName">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            the name of the rate plan<p/>
-                            
-                            Comment:<br/> 
-                            The name of the specific rate plan in the tariff book. There are multiple rate names per each tariff. </xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="255"/>
-                        <xs:whiteSpace value="collapse"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="service" nillable="false" type="ServiceKind"> </xs:element>
-            <xs:element maxOccurs="unbounded" name="customerClass" type="CustomerClassKind"> </xs:element>
-            <xs:element minOccurs="0" name="territories">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" name="territory">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element maxOccurs="1" name="territoryId" type="xs:string">
-                                    </xs:element>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="ratePlanDescription">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            a brief description of the rate plan such as what type of customer it applies to and major eligibility criteria<p/>
-                            
-                            Comment:<br/> 
-                            Brief description of the tariff such as what type of customer it applies to and major eligibility criteria.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="2000"/>
-                        <xs:whiteSpace value="collapse"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="dpsCaseNumber" maxOccurs="unbounded" type="xs:string" minOccurs="0"> </xs:element>
-            <xs:element name="ratePlanHasRetailSupply" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            boolean indicating whether the rate plan is for only distribution service vs. distribution and supply service with ESCO retail supply (i.e. "TRUE"if  there is retail supply)<p/>
-                            
-                            Comment:<br/> 
-                            boolean indicating whether the rate plan is for only distribution service vs. distribution and supply service with ESCO retail supply. If "TRUE" they have an ESCO for supply; if "FALSE" then they don't have an ESCO for supply.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:boolean"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanHasTieredBlocks" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            boolean indicating whether the rate plan includes a baseline allowance (TRUE or FALSE)<p/>
-                            
-                            Comment:<br/> 
-                            Boolean indicating whether the rate includes a baseline allowance</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:boolean"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanHasDemandCharges" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            boolean indicating whether the rate plan includes Demand Charges (TRUE or FALSE)<p/>
-                            
-                            Comment:<br/> 
-                            Boolean indicating whether the rate includes Demand Charges</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:boolean"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanHasIcapTag" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            boolean indicating whether the rate plan calculation is subject to the ICAP tag of a given customer (TRUE or FALSE)<p/>
-                            
-                            Comment:<br/> 
-                            Rate calculation is subject to the ICAP tag of a given customer</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:boolean"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanHasReactivePower" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            boolean indicating whether the rate plan includes Reactive Power Charges (TRUE or FALSE)<p/>
-                            
-                            Comment:<br/> 
-                            Boolean indicating whether the rate includes Reactive Power Charges</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:boolean"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanHasTimeOfUsePricing" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            boolean indicating whether the rate plan includes Time of Use (TOU) Pricing (TRUE or FALSE)<p/>
-                            
-                            Comment:<br/> 
-                            Boolean indicating whether the rate includes Time of Use Pricing</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:boolean"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanIsRateRider" minOccurs="0">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> 
-                            boolean indicating whether the rate plan is defined in the tariff book or a rider to the tariff book (TRUE or FALSE)<p/>
-                            
-                            Comment:<br/> 
-                            Whether the rate is defined in the tariff book or a rider to the tariff book. </xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:boolean"> </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="ratePlanNumberRatePeriods" nillable="true">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Tooltip:<br/> the number of rate periods associated with
-                            the rate plan, counting 1 for each period occurrence for each season and
-                            weekday type<p/> Comment:<br/> The number of periods associated with the
-                            rate, counting 1 for each period occurrence in each season (e.g. 3 off
-                            peak/base/peak periods means 6 periods for winter and summer combined).
-                            This is used to inform programming of devices that operate (turn on/off,
-                            charge, import/export) based on time of use
-                            schedules.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:int">
-                        <xs:totalDigits value="2"/>
-                        <xs:minExclusive value="0"/>
-                    </xs:restriction>
                 </xs:simpleType>
             </xs:element>
         </xs:sequence>

--- a/tariff_books.xsd
+++ b/tariff_books.xsd
@@ -46,7 +46,6 @@
                                                   name="ratePlanOption">
                                                   <xs:complexType>
                                                   <xs:sequence>
-                                                  <xs:element ref="tariffBookLeafRanges"/>
                                                   <xs:element name="ratePlan">
                                                   <xs:complexType>
                                                   <xs:complexContent>
@@ -57,6 +56,7 @@
                                                   </xs:complexContent>
                                                   </xs:complexType>
                                                   </xs:element>
+                                                  <xs:element ref="tariffBookLeafRanges"/>
                                                   <xs:element minOccurs="0" ref="eligibility"/>
                                                   <xs:element minOccurs="0" ref="seasons"/>
                                                   <xs:element minOccurs="0" ref="holidays"/>
@@ -100,19 +100,26 @@
                         <xs:sequence>
                             <xs:element name="startLeafNumber" type="xs:string"/>
                             <xs:element name="endLeafNumber" type="xs:string"/>
-                            <xs:element name="dpsCaseNumber" maxOccurs="unbounded" type="xs:string"/>
-                            <xs:element name="receivedDate" type="xs:date"/>
-                            <xs:element name="initialEffectiveDate" type="xs:date"/>
-                            <xs:element name="effectiveDate" type="xs:date"/>
-                            <xs:element name="revisionNumber" type="xs:int"/>
-                            <xs:element name="supersedingRevisionNumber"/>
-                            <xs:element name="status">
-                                <xs:simpleType>
-                                    <xs:restriction base="xs:string">
-                                        <xs:enumeration value="EFFECTIVE"/>
-                                        <xs:enumeration value="PENDING"/>
-                                    </xs:restriction>
-                                </xs:simpleType>
+                            <xs:element name="startLeafMetadata">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="receivedDate" type="xs:date"/>
+                                        <xs:element name="initialEffectiveDate" type="xs:date"/>
+                                        <xs:element name="effectiveDate" type="xs:date"/>
+                                        <xs:element name="dpsCaseNumber" maxOccurs="unbounded"
+                                            type="xs:string"/>
+                                        <xs:element name="status">
+                                            <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                  <xs:enumeration value="EFFECTIVE"/>
+                                                  <xs:enumeration value="PENDING"/>
+                                                </xs:restriction>
+                                            </xs:simpleType>
+                                        </xs:element>
+                                        <xs:element name="revisionNumber" type="xs:int"/>
+                                        <xs:element name="supersedingRevisionNumber"/>
+                                    </xs:sequence>
+                                </xs:complexType>
                             </xs:element>
                         </xs:sequence>
                     </xs:complexType>


### PR DESCRIPTION
tariffBook input schema and data_output schema:
RatePlanType
Added "applicability"
Grouped related elements into nested sets
ConstraintVariableType
Introduced "endUses" "equipment", "onSiteGenerationProfile" and "ServiceProvision"

added "enrollment" to "eligibility". This is in response to Adam's point about the overlap between eligibility criteria and "scopeOfApplicability" (example: "customer class")

streamlines settings in output file