### PR TITLE
Generate docs based on release tag, instead of destination directory

### DIFF
--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Validate existing tag
       run: |
-        if ! [[ git tag -l ${{ inputs.releaseTag }} == ${{ inputs.releaseTag }} ]]; then
+        if ! [[ $(git tag -l ${{ inputs.releaseTag }}) ]]; then
           echo "Please enter a valid release tag.";
           exit 1;
         fi

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Validate/Checkout existing tag
       run: |
         cd main
-        if ! [[ $(git tag -l ${{ inputs.releaseTag }}) ]]; then
+        if ! [[ git tag -l | egrep -q "^${{ inputs.releaseTag }}$" ]]; then
           echo "::error::Please enter an existing release tag.";
           exit 1;
         fi

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Validate/Checkout existing tag
       run: |
         cd main
-        if [[ $(git tag -l ${{ inputs.releaseTag }}) != ${{ inputs.releaseTag }}) ]]; then
+        if [[ $(git tag -l ${{ inputs.releaseTag }}) != ${{ inputs.releaseTag }} ]]; then
           echo "::error::Please enter an existing release tag.";
           exit 1;
         fi

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,7 +38,8 @@ jobs:
     - name: Validate/Checkout existing tag
       run: |
         cd main
-        git tag -l 
+        TAGS=`git tag -l`
+        echo $TAGS
         if [[ $(git tag -l ${{ inputs.releaseTag }}) != ${{ inputs.releaseTag }} ]]; then
           echo "::error::Please enter an existing release tag.";
           exit 1;

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Validate input 
       run: |
         if ! [[ "${{ inputs.releaseTag }}" =~ ^[0-9a-zA-Z._-]+$ ]]; then
-          echo "Please enter a well-formed release tag.";
+          echo "::error::Please enter a well-formed release tag.";
           exit 1;
         fi
       shell: bash
@@ -39,7 +39,7 @@ jobs:
       run: |
         cd main
         if ! [[ $(git tag -l ${{ inputs.releaseTag }}) ]]; then
-          echo "Please enter an existing release tag.";
+          echo "::error::Please enter an existing release tag.";
           exit 1;
         fi
         git checkout ${{ inputs.releaseTag }}

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Validate/Checkout existing tag
       run: |
         cd main
-        if ! [[ git tag -l | egrep -q "^${{ inputs.releaseTag }}$" ]]; then
+        if ! [[ $(git tag -l | egrep -q "^${{ inputs.releaseTag }}$") ]]; then
           echo "::error::Please enter an existing release tag.";
           exit 1;
         fi

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -31,14 +31,15 @@ jobs:
 
     - name: Checkout main repo.
       uses: actions/checkout@v4
+      continue-on-error: true
       with:
         path: main
         ref: ${{ inputs.releaseTag }}
 
     - name: Validate existing tag
       run: |
-        if ! [[ git -l "${{ inputs.releaseTag }}" ]]; then
-          echo "Please enter a valid releast tag.";
+        if ! [[ git -l ${{ inputs.releaseTag }} == ${{ inputs.releaseTag }} ]]; then
+          echo "Please enter a valid release tag.";
           exit 1;
         fi
       shell: bash

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Validate/Checkout existing tag
       run: |
         cd main
-        if [[ $(git tag -l | egrep -q "^${{ inputs.releaseTag }}$") != 0 ]]; then
+        if [[ $(git tag -l ${{ inputs.releaseTag }}) != ${{ inputs.releaseTag }}) ]]; then
           echo "::error::Please enter an existing release tag.";
           exit 1;
         fi

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -34,6 +34,8 @@ jobs:
       continue-on-error: true
       with:
         path: main
+        fetch-depth: 0
+        fetch-tags: 1
 
     - name: Validate/Checkout existing tag
       run: |

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -40,8 +40,6 @@ jobs:
     - name: Validate/Checkout existing tag
       run: |
         cd main
-        TAGS=`git tag -l`
-        echo $TAGS
         if [[ $(git tag -l ${{ inputs.releaseTag }}) != ${{ inputs.releaseTag }} ]]; then
           echo "::error::Please enter an existing release tag.";
           exit 1;

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Validate/Checkout existing tag
       run: |
         cd main
-        if ! [[ $(git tag -l | egrep -q "^${{ inputs.releaseTag }}$") ]]; then
+        if [[ $(git tag -l | egrep -q "^${{ inputs.releaseTag }}$") != 0 ]]; then
           echo "::error::Please enter an existing release tag.";
           exit 1;
         fi

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -34,14 +34,16 @@ jobs:
       continue-on-error: true
       with:
         path: main
-        ref: ${{ inputs.releaseTag }}
 
-    - name: Validate existing tag
+    - name: Validate/Checkout existing tag
       run: |
+        cd main
         if ! [[ $(git tag -l ${{ inputs.releaseTag }}) ]]; then
-          echo "Please enter a valid release tag.";
+          echo "Please enter an existing release tag.";
           exit 1;
         fi
+        git checkout ${{ inputs.releaseTag }}
+        cd ${{ github.workspace }}
       shell: bash
 
     - name: Install Java 

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Validate/Checkout existing tag
       run: |
         cd main
+        git tag -l 
         if [[ $(git tag -l ${{ inputs.releaseTag }}) != ${{ inputs.releaseTag }} ]]; then
           echo "::error::Please enter an existing release tag.";
           exit 1;

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -2,8 +2,8 @@ name: Generate Oxygen Schema Docs
 on:
   workflow_dispatch:
     inputs:
-      docsDirectory:
-        description: 'Version of documentation (directory name) to create/overwrite'
+      releaseTag:
+        description: 'Release tag of documentation to create/overwrite'
         required: true
 
 ##
@@ -21,10 +21,10 @@ jobs:
       SCRIPTING_LICENSE_KEY: ${{secrets.SCRIPTING_LICENSE_KEY}}
 
     steps:
-    - name: Validate input
+    - name: Validate input 
       run: |
-        if ! [[ "${{ inputs.docsDirectory }}" =~ ^[0-9a-zA-Z._-]+$ ]]; then
-          echo "Please enter a valid directory name.";
+        if ! [[ "${{ inputs.releaseTag }}" =~ ^[0-9a-zA-Z._-]+$ ]]; then
+          echo "Please enter a well-formed release tag.";
           exit 1;
         fi
       shell: bash
@@ -33,6 +33,15 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: main
+        ref: ${{ inputs.releaseTag }}
+
+    - name: Validate existing tag
+      run: |
+        if ! [[ git -l "${{ inputs.releaseTag }}" ]]; then
+          echo "Please enter a valid releast tag.";
+          exit 1;
+        fi
+      shell: bash
 
     - name: Install Java 
       uses: actions/setup-java@v4
@@ -67,20 +76,20 @@ jobs:
       run: |
         cd scripting/oxygen
         mkdir output
-        if [ -d ${{ github.workspace }}/rate-plan-documentation/doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.docsDirectory }} ]; then
+        if [ -d ${{ github.workspace }}/rate-plan-documentation/doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.releaseTag }} ]; then
           echo "Deleting contents of existing directory"
-          rm -rf ${{ github.workspace }}/rate-plan-documentation/doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.docsDirectory }}/*
+          rm -rf ${{ github.workspace }}/rate-plan-documentation/doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.releaseTag }}/*
         fi
         generate_schema_doc() {
           BASENAME=$1
-          mkdir -p ${{ github.workspace }}/rate-plan-documentation/doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.docsDirectory }}/${BASENAME}
+          mkdir -p ${{ github.workspace }}/rate-plan-documentation/doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.releaseTag }}/${BASENAME}
           mkdir output/${BASENAME}
           ./scripts/schemaDocumentation.sh ${{ github.workspace }}/main/${BASENAME}.xsd -cfg:${{ github.workspace }}/main/.github/workflows/docgen_settings.xml -out:${{ github.workspace }}/scripting/oxygen/output/${BASENAME}/${BASENAME}.html   -format:html -split:namespace
         }
         generate_schema_doc "all_rate_plan_schemas"
         generate_schema_doc "rate_plan_data_input"
         generate_schema_doc "rate_plan_data_output"
-        cp -r output/* ${{ github.workspace }}/rate-plan-documentation/doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.docsDirectory }}/
+        cp -r output/* ${{ github.workspace }}/rate-plan-documentation/doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.releaseTag }}/
       shell: bash
 
     - name: Create Pull Request
@@ -88,8 +97,8 @@ jobs:
       with:
         token: ${{ secrets.GIT_RATE_SCHEMA_DOCUMENTATION_TOKEN }}
         path: rate-plan-documentation
-        add-paths: doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.docsDirectory }}/
+        add-paths: doc/OxygenDocs/rate-plan-schema-docs/${{ inputs.releaseTag }}/
         branch: fluxbot-doc-updates
         branch-suffix: timestamp
-        title: "[Flux Bot] New version of schema documentation - ${{ inputs.docsDirectory }}"
+        title: "[Flux Bot] New version of schema documentation - ${{ inputs.releaseTag }}"
         commit-message: "[Flux Bot] New version of schema documentation"

--- a/.github/workflows/generate-schema-docs.yml
+++ b/.github/workflows/generate-schema-docs.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Validate existing tag
       run: |
-        if ! [[ git -l ${{ inputs.releaseTag }} == ${{ inputs.releaseTag }} ]]; then
+        if ! [[ git tag -l ${{ inputs.releaseTag }} == ${{ inputs.releaseTag }} ]]; then
           echo "Please enter a valid release tag.";
           exit 1;
         fi


### PR DESCRIPTION
This branch updates the `Generate Oxygen Schema Docs` workflow so that it takes the a release tag as input (NOT the destination directory).  It will then open a PR to the documentation repo with the docs in a directory with the same name as the release tag.

The Workflow validates that the release tag exists after submission, but there is no way to create a pulldown with tags in the workflow. 

Note: If the docs have already been published a PR will not be opened (git knows there are no new changes)  TODO: Alert the user when this happens.